### PR TITLE
support if statement in Debian 9:

### DIFF
--- a/wwatson
+++ b/wwatson
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-if [ $1 == "start" ]; then
+if [ "$1" = "start" ]; then
 	window_activity.sh&
 	capture_screenshots.sh 300 "$HOME/Pictures/screenshots/$2"&
 fi
 
-if [ $1 == "stop" ] && [ $# == 1 ] ; then
+if [ "$1" = "stop" ] && [ $# = 1 ] ; then
 	killall -HUP window_activity.sh capture_screenshots.sh
 fi
 


### PR DESCRIPTION
if statement in Debian 9 using sh get the follow error

./wwatson: 2: [: s: unexpected operator
./wwatson: 7: [: s: unexpected operator

System information:
moe :: ~/sources/watson_wrapper ‹master*› » dpkg -S /bin/sh
diversion by dash from: /bin/sh
diversion by dash to: /bin/sh.distrib
dash: /bin/sh
moe :: ~/sources/watson_wrapper ‹master*› » apt-cache show dash
Package: dash
Version: 0.5.8-2.4
Essential: yes
Installed-Size: 211
Maintainer: Gerrit Pape <pape@smarden.org>
Architecture: i386
Depends: debianutils (>= 2.15), dpkg (>= 1.15.0)
Pre-Depends: libc6 (>= 2.11)
Description-en: POSIX-compliant shell
 The Debian Almquist Shell (dash) is a POSIX-compliant shell derived
 from ash.
 .
 Since it executes scripts faster than bash, and has fewer library
 dependencies (making it more robust against software or hardware
 failures), it is used as the default system shell on Debian systems.
Description-md5: 8d4d9c32c6b2b70328f7f774a0cc1248
Homepage: http://gondor.apana.org.au/~herbert/dash/
Tag: implemented-in::c, interface::shell, role::program, scope::utility
Section: shells
Priority: required
Filename: pool/main/d/dash/dash_0.5.8-2.4_i386.deb
Size: 113932
MD5sum: 0df91f9438973bfde830aa00ccad9e2c
SHA256: 6f84f57339845db0a9497fb047f6117d65091a04e67b5158c47247fe9686fd05